### PR TITLE
Add fix for logging of the Ninja Battle message in ApplicationInsight…

### DIFF
--- a/4-Functions_Lab/readme.md
+++ b/4-Functions_Lab/readme.md
@@ -165,11 +165,11 @@ Now that we have an event hub let's create an instance of CosmosDB where we can 
 
     ```javascript
         module.exports = function (context, eventHubMessages) {
-            context.log(`JavaScript eventhub trigger function called for message array ${eventHubMessages}`);
+            context.log(`JavaScript eventhub trigger function called for message array ${JSON.stringify(eventHubMessages)}`);
             var messages = [];
 
             eventHubMessages.forEach(message => {
-                context.log(`Processed message ${message}`);
+                context.log(`Processed message ${message.description}`);
                 messages.push(message);
             });
 


### PR DESCRIPTION
…s Trace panel message display

On ApplicationInsights, during the Azure Cloud Functions workshop, we noticed in ApplicationInsights that when sending messages from the eventgenerator (https://eventgenerator.azurewebsites.net/gui) for the "Event Hub" example, using "Ninja Battle", that the logged messages for logged Trace records were displayed as [object Object].  

It appears that an array of objects are being sent.  Updating code to display the description object property.
![fixapplied](https://user-images.githubusercontent.com/1182771/36225835-d0fcf084-1180-11e8-92c0-7d732ec0d2b1.PNG)
