### PR TITLE
Update readme.md

### DIFF
--- a/4-Functions_Lab/readme.md
+++ b/4-Functions_Lab/readme.md
@@ -304,7 +304,7 @@ Now that we have an event hub let's create an instance of CosmosDB where we can 
     ```javascript
     module.exports = function (context, eventGridEvent) {
         context.log(eventGridEvent);
-        context.done(null, eventGridEvent);
+        context.done(null, {document: eventGridEvent});
     };
     ```
 


### PR DESCRIPTION
The JavaScript Function for processing the EventGrid Subscription and writing to Cosmos DB does not actually write to Cosmos DB. At least it did not work for me unless I did the following:

context.binding.document=eventGridEvent;
context.done();

or

context.done(null,{document: eventGridEvent});